### PR TITLE
Remove current screen check

### DIFF
--- a/src/main/java/jugglestruggle/timechangerstruggle/client/TimeChangerStruggleClient.java
+++ b/src/main/java/jugglestruggle/timechangerstruggle/client/TimeChangerStruggleClient.java
@@ -357,7 +357,7 @@ public class TimeChangerStruggleClient implements ClientModInitializer
 	{
 		// TODO: Is there a better way to call key events on press and releases without the need of ticking?
 		
-		if (client.currentScreen == null && client.world != null)
+		if (client.world != null)
 		{
 			if (Keybindings.timeChangerMenuKey.isPressed()) {
 				client.setScreen(new TimeChangerScreen());


### PR DESCRIPTION
This is a simple fix for using mod functions inside ReplayMod (Possibility in other mods too.) by removing current screen check.

![image](https://user-images.githubusercontent.com/6128413/188095100-2d5e8eab-47ce-4c46-acbb-7a03d14f3253.png)